### PR TITLE
Revert "Added regex to remove console colors. Fixes #306 "

### DIFF
--- a/src/plugins/ExecutePipeline/templates/index.js
+++ b/src/plugins/ExecutePipeline/templates/index.js
@@ -11,7 +11,7 @@ define([
     DESERIALIZE
 ) {
 
-    var BASH = `th init.lua  2>&1 | sed -e 's/[[:cntrl:]]//g' -e 's/\\[32;1m//g' -e 's/\\[0;36m//g' -e 's/\\[33;1m//g' -e 's/\\[35;1m//g' -e 's/\\[37;1m//g' -e 's/\\[0m//g'`;
+    var BASH = 'th init.lua  2>&1';
     return {
         BASH,
         ENTRY,


### PR DESCRIPTION
Reverts dfst/deepforge#307

This was preventing the real time (+/- 1.5 s) logging. This should probably be fixed in the browser and set the colors correctly