### PR TITLE
Added run.sh script to execution files. Fixes #818

### DIFF
--- a/src/plugins/ExecuteJob/ExecuteJob.js
+++ b/src/plugins/ExecuteJob/ExecuteJob.js
@@ -83,7 +83,10 @@ define([
         var type = this.core.getMetaType(this.activeNode),
             typeName = type && this.getAttribute(type, 'name');
 
-        // TODO: Set the baseURL from the config
+        // This might be tough...
+        this.baseURL = this.getCurrentConfig().baseURL;
+
+        // TODO: Pass the baseURL in the plugin config
         if (typeName !== 'Job') {
             return callback(`Cannot execute ${typeName} (expected Job)`, this.result);
         }
@@ -481,7 +484,7 @@ define([
                         var input = inputs[i], 
                             hash = files.inputAssets[input],
                             dataPath = 'inputs/' + input + '/data',
-                            url = this.baseURL + this.blobClient.getDownloadURL(hash);
+                            url = this.baseURL + this.blobClient.getRelativeDownloadURL(hash);
 
                         inputData[dataPath] = {
                             req: hash,


### PR DESCRIPTION
Added a `run.sh` script to be used for reproducing jobs locally. `run.sh` is a bash script which will download the data from the deepforge server and then run the operation code. After a failed execution, the execution files can be downloaded from the web ui. Then, after unzipping and changing into the unzipped directory, the job can be replicated with:

```
DEEPFORGE_URL=http://localhost:8888 bash run.sh
```
If running deepforge on a remote machine (rather than locally), the `DEEPFORGE_URL` value should be updated accordingly