### PR TITLE
Updated webgme version to v2.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "nodemon": "^1.9.2",
     "q": "1.4.1",
     "rimraf": "^2.4.0",
-    "webgme": "^2.0.0",
+    "webgme": "^2.6.0",
     "webgme-autoviz": "^2.2.0",
     "webgme-breadcrumbheader": "^2.1.1",
     "webgme-chflayout": "^2.0.0",


### PR DESCRIPTION
Updating webgme fixed this issue: https://github.com/webgme/webgme/issues/1145. If there are problems w/ larger files/slower networks, the server upload timeout can be adjusted (or exposed in the cli config)